### PR TITLE
feat: Should check app guards when getting User

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,32 @@
 {
-    "name": "floorbox/event-tracker",
-    "description": "An event tracker for Laravel",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-      {
-        "name": "Fa Perreault",
-        "email": "fa.perreault@thefloorbox.ca"
-      }
-    ],
-    "require": {
-        "php": "^8.2",
-        "laravel/framework": "^10.0",
-        "lorisleiva/laravel-actions": "^2.4"
-      },
-
+  "name": "floorbox/event-tracker",
+  "description": "An event tracker for Laravel",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Fa Perreault",
+      "email": "fa.perreault@thefloorbox.ca"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "laravel/framework": "^10.0|^11.0|^12.0",
+    "lorisleiva/laravel-actions": "^2.4"
+  },
   "autoload": {
     "psr-4": {
       "EventTracker\\": "src"
     }
-    },
+  },
   "extra": {
     "laravel": {
-        "providers": [
-          "EventTracker\\EventTrackerServiceProvider"
-        ],
-        "aliases": {
-          "EventTracker": "EventTracker\\Facades\\EventTracker"
-        }
+      "providers": [
+        "EventTracker\\EventTrackerServiceProvider"
+      ],
+      "aliases": {
+        "EventTracker": "EventTracker\\Facades\\EventTracker"
       }
+    }
   }
 }

--- a/src/Services/EventTrackerService.php
+++ b/src/Services/EventTrackerService.php
@@ -53,23 +53,28 @@ class EventTrackerService
         );
     }
 
-    private function getActingUser()
+    private function getActingUser(): ?int
     {
         $actingUserId = auth()->id();
 
-        if (!$actingUserId) {
-            $actingUserId = auth()->user()?->id ?? null;
+        if ($actingUserId) {
+            return $actingUserId;
         }
 
-        if (!$actingUserId) {
-            $actingUserId = auth('web')->user()?->id ?? null;
+        foreach (array_keys((array) config('auth.guards', [])) as $guardName) {
+            try {
+                $guardUserId = auth($guardName)->id();
+            } catch (\Throwable $e) {
+                report($e);
+                continue;
+            }
+
+            if ($guardUserId) {
+                return $guardUserId;
+            }
         }
 
-        if (!$actingUserId) {
-            $actingUserId = auth('api')->user()?->id ?? null;
-        }
-
-        return $actingUserId;
+        return null;
     }
 
 }


### PR DESCRIPTION
close https://github.com/floorbox/pyle-support/issues/294
admin https://github.com/floorbox/floorbox-admin/pull/1413
floorbox https://github.com/floorbox/floorbox-api/pull/4739
pyle https://github.com/pylesoft/pyle/pull/339
prosol https://github.com/floorbox/prosol-api/pull/1396
prosol storefront https://github.com/floorbox/prosol-storefront/pull/556
bmb https://github.com/floorbox/bmb-app/pull/198
lauzon https://github.com/floorbox/lauzon-api/pull/734

This pull request updates the package requirements to support newer Laravel versions and improves the way the acting user is determined in the `EventTrackerService`. The main changes are:

**Framework Compatibility:**

* Updated the Laravel framework requirement in `composer.json` to support versions 10, 11, and 12, allowing the package to work with newer Laravel releases.

**User Identification Logic:**

* Refactored the `getActingUser` method in `EventTrackerService` to:
  - Explicitly declare a nullable integer return type.
  - Attempt to retrieve the acting user ID from all configured authentication guards, not just the default ones.
  - Add error handling to catch and report exceptions when accessing guard IDs.
  - Return the first found user ID or `null` if none are found, making the logic more robust and extensible.